### PR TITLE
feat: supports starting value from middle

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,11 +23,10 @@ module.exports = () => {
 
             case decl.variable && decl.value.startsWith('z-stack('): {
               const explicitValue = decl.value.match(REGEXP_STACK).groups.value
-              if (explicitValue && stackedVariable) {
-                throw decl.error('z-stack with starting value should be first')
-              }
               const startingZ = explicitValue || '1'
-              decl.value = stackedVariable ? `calc(var(${stackedVariable}) + 1)` : startingZ
+              decl.value = stackedVariable ? (
+                explicitValue !== '' ? explicitValue : `calc(var(${stackedVariable}) + 1)`
+              ) : startingZ
               stackedVariable = decl.prop
               return
             }

--- a/index.test.js
+++ b/index.test.js
@@ -82,7 +82,7 @@ describe('postcss-easy-z', () => {
       await run(input, output)
     })
 
-    it('fails if starting value is not first', async () => {
+    it('works if starting value is not first', async () => {
       const input = `
         :root {
           --z-content: z-stack();
@@ -91,7 +91,15 @@ describe('postcss-easy-z', () => {
         }
       `
 
-      await expect(process(input)).rejects.toThrow('z-stack with starting value should be first')
+      const output = `
+        :root {
+          --z-content: 1;
+          --z-header: 10;
+          --z-popup: calc(var(--z-header) + 1);
+        }
+      `
+
+      await run(input, output)
     })
   })
 


### PR DESCRIPTION
Hi,
I think allowing an explicit value in the middle of the stack can provide convenience dealing with UI frameworks, like Material-UI which takes `1300` as their modal/drawer default `z-index`.